### PR TITLE
Added redirects for Codehaus Cargo's JIRA entries

### DIFF
--- a/includes/jira.codehaus.org.inc
+++ b/includes/jira.codehaus.org.inc
@@ -138,6 +138,11 @@ RewriteRule "^/browse/MVFS(.*)$" "https://github.com/mojohaus/vfs/issues" [L]
 #RewriteRule "^/browse/MXMLBEANS(.*)$" "https://github.com/mojohaus/xmlbeans-maven-plugin/issues" [L]
 
 ##################################
+# Owned by: S. Ali Tokmen        #
+##################################
+RewriteRule "^/browse/CARGO(.*)$" "https://codehaus-cargo.atlassian.net/browse/CARGO$1" [L]
+
+##################################
 # Owned by: support@codehaus.org #
 ##################################
 RewriteRule "/browse/MAVENPROXY" "https://www.codehaus.org/termination.html"


### PR DESCRIPTION
Added redirects for Codehaus Cargo's JIRA entries, as there are many links existing on the internet. The CARGO-\* issue numbers match as we did a full import.
