### PR TITLE
Changed the entry for CARGO to be [R=301,L]

### DIFF
--- a/includes/jira.codehaus.org.inc
+++ b/includes/jira.codehaus.org.inc
@@ -140,7 +140,7 @@ RewriteRule "^/browse/MVFS(.*)$" "https://github.com/mojohaus/vfs/issues" [L]
 ##################################
 # Owned by: S. Ali Tokmen        #
 ##################################
-RewriteRule "^/browse/CARGO(.*)$" "https://codehaus-cargo.atlassian.net/browse/CARGO$1" [L]
+RewriteRule "^/browse/CARGO(.*)$" "https://codehaus-cargo.atlassian.net/browse/CARGO$1" [R=301,L]
 
 ##################################
 # Owned by: support@codehaus.org #


### PR DESCRIPTION
Now tested, and for example http://jira.codehaus.org/browse/CARGO-1005 redirects to https://codehaus-cargo.atlassian.net/browse/CARGO-1005 as expected. Setting redirect to be permanent (301).
