### PR TITLE
Added redirects for http://cargo.codehaus.org/

### DIFF
--- a/conf/cargo.codehaus.org.conf
+++ b/conf/cargo.codehaus.org.conf
@@ -1,0 +1,23 @@
+<VirtualHost *:443>
+  ServerName cargo.codehaus.org
+  ServerAdmin support@codehaus.org
+  RewriteEngine on
+
+  Include ssl.d/WILDCARD.codehaus.org.conf
+
+  Include redirector/includes/abuse.inc
+
+  Include redirector/includes/cargo.codehaus.org.inc
+</VirtualHost>
+
+<VirtualHost *:80>
+  ServerName cargo.codehaus.org
+  ServerAdmin support@codehaus.org
+  RewriteEngine on
+
+  Include redirector/includes/abuse.inc
+
+  Include redirector/includes/cargo.codehaus.org.inc
+</VirtualHost>
+
+

--- a/includes/cargo.codehaus.org.inc
+++ b/includes/cargo.codehaus.org.inc
@@ -1,0 +1,13 @@
+##################################
+# RULES                          #
+##################################
+
+# Customer rules here
+
+RewriteRule "^/([^\.]+)\.(.*)$" "https://codehaus-cargo.github.io/cargo/$1.$2"
+RewriteRule "^/(.+)$" "https://codehaus-cargo.github.io/cargo/$1.html"
+
+##################################
+# FALLBACK                       #
+##################################
+RewriteRule    "^.*"  "https://codehaus-cargo.github.io/"


### PR DESCRIPTION
Added redirects for http://cargo.codehaus.org/
- Redirect all files directly: http://cargo.codehaus.org/([^\.]+)\.(.*) to https://codehaus-cargo.github.io/cargo/$1.$2
- Redirect all pages (beforehand rendered using the vm methods) to the associated HTML pages: http://cargo.codehaus.org/(.+) to https://codehaus-cargo.github.io/cargo/$1.html

And then, we have our fallback redirect to https://codehaus-cargo.github.io/
