### PR TITLE
added GMavenPlus root redirect

### DIFF
--- a/conf/gmavenplus.codehaus.org.conf
+++ b/conf/gmavenplus.codehaus.org.conf
@@ -1,0 +1,23 @@
+<VirtualHost *:443>
+  ServerName gmavenplus.codehaus.org
+  ServerAdmin support@codehaus.org
+  RewriteEngine on
+
+  Include ssl.d/WILDCARD.codehaus.org.conf
+
+  Include redirector/includes/abuse.inc
+
+  Redirect / https://github.com/groovy/GMavenPlus/
+
+</VirtualHost>
+
+<VirtualHost *:80>
+  ServerName gmavenplus.codehaus.org
+  ServerAdmin support@codehaus.org
+  RewriteEngine on
+
+  Include redirector/includes/abuse.inc
+
+  Redirect / https://github.com/groovy/GMavenPlus/
+
+</VirtualHost>


### PR DESCRIPTION
I think I just need the `conf` and not an `includes` to point http://gmavenplus.codehaus.org/ to https://github.com/groovy/GMavenPlus/, but let me know if I'm mistaken.
