### PR TITLE
Add redirect for jaxen.codehaus.org/* -> jaxen.org/*

### DIFF
--- a/conf/jaxen.codehaus.org.conf
+++ b/conf/jaxen.codehaus.org.conf
@@ -1,0 +1,23 @@
+<VirtualHost *:443>
+  ServerName jaxen.codehaus.org
+  ServerAdmin support@codehaus.org
+  RewriteEngine on
+
+  Include ssl.d/WILDCARD.codehaus.org.conf
+
+  Include redirector/includes/abuse.inc
+
+  Redirect / http://www.jaxen.org/
+
+</VirtualHost>
+
+<VirtualHost *:80>
+  ServerName jaxen.codehaus.org
+  ServerAdmin support@codehaus.org
+  RewriteEngine on
+
+  Include redirector/includes/abuse.inc
+
+  Redirect / http://www.jaxen.org/
+
+</VirtualHost>


### PR DESCRIPTION
http://jaxen.org has 1.1.2 from 2008
[jaxen.codehaus.org on archive.org](http://web.archive.org/web/20150514013237/http://jaxen.codehaus.org/) shows 1.1.6 from 2015 as last live version

Added 302 to have something, it's better than the current "terminated" redirect.
